### PR TITLE
Add initial FuseSoC support

### DIFF
--- a/misato.core
+++ b/misato.core
@@ -1,0 +1,35 @@
+CAPI=2:
+
+name : ::misato:0
+
+filesets:
+  openlane:
+    files : [params.tcl : {file_type : tclSource}]
+
+targets:
+  default:
+    generate : [misato]
+
+  lint:
+    default_tool : verilator
+    generate : [misato]
+    tools:
+      verilator:
+        mode : lint-only
+    toplevel : top
+
+  sky130:
+    default_tool : openlane
+    filesets : [openlane]
+    generate : [misato]
+    toplevel : top
+
+generate:
+  misato:
+    generator: misatogen
+
+generators:
+  misatogen:
+    interpreter: python3
+    command: misatogen.py
+    description: Create a Verilog description from the Misato Amaranth design

--- a/misatogen.py
+++ b/misatogen.py
@@ -1,0 +1,22 @@
+from fusesoc.capi2.generator import Generator
+
+from amaranth import *
+from amaranth.back import verilog
+
+from isa import XLEN
+from cpu import Misato
+
+class MisatoGenerator(Generator):
+    def run(self):
+        cpu = Misato(xlen=XLEN.RV32, with_RVFI=False, formal=False)
+        with open("cpu.v", "w") as file:
+            file.write(verilog.convert(cpu, ports=cpu.ports()))
+
+        files = [
+            {"cpu.v" : {"file_type" : "verilogSource"}}]
+
+        self.add_files(files)
+
+g = MisatoGenerator()
+g.run()
+g.write()

--- a/params.tcl
+++ b/params.tcl
@@ -1,0 +1,6 @@
+set ::env(CLOCK_PERIOD) "10"
+set ::env(CLOCK_PORT) "clk"
+set ::env(DESIGN_IS_CORE) 0
+
+set ::env(FP_SIZING) "absolute"
+set ::env(DIE_AREA) "0 0 1000 1000"


### PR DESCRIPTION
This adds FuseSoC support for Misato through the following components

misatogen.py: A FuseSoC generator that turns Misato Amaranth code into verilog+a core description file

params.tcl: A configuration file for OpenLANE

misato.core: The FuseSoC core description files with two targets, lint and sky130

The lint target uses verilator to lint the generated Amaranth code. Use with

`fusesoc run --target=lint misato`

The sky130 target builds a GDS of Misato with openlane. To avoid needing to have the tools installed locally, it is irecommended to use the Edalize-provided `el_docker` launcher script to run the tools from containers (this can be used for verilator and the lint target as well if a local verilator isn't in place). run with

`EDALIZE_LAUNCHER=el_docker fusesoc run --target=sky130 misato`

