### PR TITLE
Add Github CI action to build GDS with FuseSoC

### DIFF
--- a/.github/workflows/openlane.yml
+++ b/.github/workflows/openlane.yml
@@ -1,0 +1,23 @@
+name: build-openlane-sky130
+on: [push]
+jobs:
+  build-openlane:
+    runs-on: ubuntu-latest
+    env:
+      REPO : misato
+      VLNV : misato
+    steps:
+      - name: Checkout Misato
+        uses: actions/checkout@v2
+        with:
+          path: misato
+      - name: Install Amaranth and FuseSoC
+        run: |
+          pip3 install amaranth
+          pip3 install amaranth-yosys
+          pip3 install git+git://github.com/amaranth-lang/amaranth-boards.git
+          pip3 install git+git://github.com/amaranth-lang/amaranth-soc.git
+          pip3 install fusesoc
+      - run: echo "EDALIZE_LAUNCHER=el_docker" >> $GITHUB_ENV
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=sky130 $VLNV


### PR DESCRIPTION
This adds a Github action that builds a GDS file with OpenLANE through FuseSoC and Edalize.

Todo: Allocated area is too large and attempted clock frequency is too high. params.tcl should be tweaked for better results